### PR TITLE
Add workflow for flake.lock updates

### DIFF
--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -1,0 +1,20 @@
+name: Update flake.lock
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: DeterminateSystems/update-flake-lock@v20
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr-title: "chore: update flake.lock"
+          commit-msg: "chore: update flake.lock"
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to automatically update flake.lock
- ensure the weekly job has required permissions

## Testing
- `nix flake check` *(fails: command not found)*
- `git status --short`
