### PR TITLE
Add GitHub Actions updater workflow

### DIFF
--- a/.github/workflows/update-github-actions.yaml
+++ b/.github/workflows/update-github-actions.yaml
@@ -1,0 +1,18 @@
+name: Renovate GitHub Actions
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Run Renovate
+        uses: renovatebot/github-action@v39.3.3
+        env:
+          RENOVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["config:base"],
+  "semanticCommits": true,
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a scheduled workflow to keep GitHub Actions up to date using Renovate
- configure Renovate for conventional commit messages

## Testing
- `nix flake check` *(fails: `nix: command not found`)*