### PR TITLE
Use Renovate for updating GitHub Actions

### DIFF
--- a/.github/workflows/update-github-actions.yaml
+++ b/.github/workflows/update-github-actions.yaml
@@ -1,0 +1,14 @@
+name: Update GitHub Actions
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: renovatebot/github-action@v40.1.11
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["config:best-practices"],
+  "semanticCommits": "enabled",
+  "semanticCommitScope": "deps",
+  "enabledManagers": ["github-actions"],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "commitMessageTopic": "GitHub Actions"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- update the updater workflow to use `renovatebot/github-action`
- add a `renovate.json` extending `config:best-practices` and enabling semantic commits for GitHub Actions

## Testing
- `nix flake check` *(fails: `nix: command not found`)*